### PR TITLE
[Chore] 패키지 구조 구성

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,52 @@
+HELP.md
+.gradle
+build/
+!gradle/wrapper/gradle-wrapper.jar
+!**/src/main/**/build/
+!**/src/test/**/build/
+
+### STS ###
+.apt_generated
+.classpath
+.factorypath
+.project
+.settings
+.springBeans
+.sts4-cache
+bin/
+!**/src/main/**/bin/
+!**/src/test/**/bin/
+
+### IntelliJ IDEA ###
+.idea
+*.iws
+*.iml
+*.ipr
+out/
+!**/src/main/**/out/
+!**/src/test/**/out/
+
+### NetBeans ###
+/nbproject/private/
+/nbbuild/
+/dist/
+/nbdist/
+/.nb-gradle/
+
+### VS Code ###
+.vscode/
+
+### Mac ###
+.DS_Store
+
+### RestDocs ###
+openapi3.yaml
+
+### Intellij IDEA ###
+.idea
+
+### FCM ###
+/src/main/resources/fcm
+
+### QueryDSL ###
+/src/main/generated

--- a/build.gradle
+++ b/build.gradle
@@ -25,6 +25,7 @@ repositories {
 
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+    implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-web'
     compileOnly 'org.projectlombok:lombok'
     runtimeOnly 'com.h2database:h2'
@@ -32,6 +33,7 @@ dependencies {
     annotationProcessor 'org.projectlombok:lombok'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+
 }
 
 tasks.named('test') {

--- a/src/main/java/backend/glloserver/global/config/JpaAuditingConfig.java
+++ b/src/main/java/backend/glloserver/global/config/JpaAuditingConfig.java
@@ -1,0 +1,9 @@
+package backend.glloserver.global.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
+@EnableJpaAuditing
+@Configuration
+public class JpaAuditingConfig {
+}

--- a/src/main/java/backend/glloserver/global/exception/CustomException.java
+++ b/src/main/java/backend/glloserver/global/exception/CustomException.java
@@ -1,0 +1,10 @@
+package backend.glloserver.global.exception;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class CustomException extends RuntimeException {
+    private final ErrorResponse errorResponse;
+}

--- a/src/main/java/backend/glloserver/global/exception/ErrorMessage.java
+++ b/src/main/java/backend/glloserver/global/exception/ErrorMessage.java
@@ -1,0 +1,4 @@
+package backend.glloserver.global.exception;
+
+public record ErrorMessage(String message) {
+}

--- a/src/main/java/backend/glloserver/global/exception/ErrorResponse.java
+++ b/src/main/java/backend/glloserver/global/exception/ErrorResponse.java
@@ -1,0 +1,9 @@
+package backend.glloserver.global.exception;
+
+import org.springframework.http.HttpStatus;
+
+public interface ErrorResponse {
+
+    HttpStatus getStatus();
+    ErrorMessage getErrorMessage();
+}

--- a/src/main/java/backend/glloserver/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/backend/glloserver/global/exception/GlobalExceptionHandler.java
@@ -1,0 +1,114 @@
+package backend.glloserver.global.exception;
+
+import jakarta.persistence.OptimisticLockException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import jakarta.validation.ConstraintViolation;
+import jakarta.validation.ConstraintViolationException;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.http.converter.HttpMessageNotReadableException;
+import org.springframework.orm.ObjectOptimisticLockingFailureException;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.MissingServletRequestParameterException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.method.annotation.HandlerMethodValidationException;
+import org.springframework.web.servlet.resource.NoResourceFoundException;
+
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.util.List;
+
+@Slf4j
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler
+    public ResponseEntity<ErrorMessage> handle(CustomException e) {
+        ErrorResponse errorResponse = e.getErrorResponse();
+        return ResponseEntity
+                .status(errorResponse.getStatus())
+                .body(errorResponse.getErrorMessage());
+    }
+
+    @ExceptionHandler
+    public ResponseEntity<ErrorMessage> handle(MethodArgumentNotValidException e) {
+        ErrorMessage errorMessage = new ErrorMessage(
+                "요청값이 유효하지 않습니다: [%s]".formatted(e.getAllErrors().get(0).getDefaultMessage()));
+        return ResponseEntity
+                .badRequest()
+                .body(errorMessage);
+    }
+
+    @ExceptionHandler
+    public ResponseEntity<ErrorMessage> handle(ConstraintViolationException e) {
+        List<String> messages = e.getConstraintViolations().stream()
+                .map(ConstraintViolation::getMessage)
+                .toList();
+        ErrorMessage errorMessage = new ErrorMessage(
+                "요청값이 유효하지 않습니다: [%s]".formatted(messages.get(0)));
+        return ResponseEntity
+                .badRequest()
+                .body(errorMessage);
+    }
+
+    @ExceptionHandler({DataIntegrityViolationException.class,
+            ObjectOptimisticLockingFailureException.class,
+            OptimisticLockException.class})
+    public ResponseEntity<ErrorMessage> handle(Exception e) {
+        ErrorMessage errorMessage = new ErrorMessage("잠시후 다시 요청해주세요.");
+        return ResponseEntity.status(HttpStatus.CONFLICT).body(errorMessage);
+    }
+
+    @ExceptionHandler
+    public ResponseEntity<ErrorMessage> handle(HandlerMethodValidationException e) {
+        ErrorMessage errorMessage = new ErrorMessage(
+                "요청값이 유효하지 않습니다: [%s]".formatted(e.getAllErrors().get(0).getDefaultMessage()));
+        return ResponseEntity
+                .badRequest()
+                .body(errorMessage);
+    }
+
+    @ExceptionHandler
+    public ResponseEntity<ErrorMessage> handle(MissingServletRequestParameterException e) {
+        ErrorMessage errorMessage = new ErrorMessage(
+                "해당 쿼리 파리미터 값이 존재하지 않습니다: [%s]".formatted(e.getParameterName()));
+        return ResponseEntity
+                .badRequest()
+                .body(errorMessage);
+    }
+
+    @ExceptionHandler
+    public ResponseEntity<ErrorMessage> handle(HttpMessageNotReadableException e) {
+        ErrorMessage errorMessage = new ErrorMessage(
+                "유효하지 않은 요청 형태입니다: [%s]".formatted(e.getMessage().split(":")[0]));
+        return ResponseEntity
+                .badRequest()
+                .body(errorMessage);
+    }
+
+    @ExceptionHandler
+    public ResponseEntity<ErrorMessage> handle(NoResourceFoundException e) {
+        ErrorMessage errorMessage = new ErrorMessage(
+                "유효하지 않은 요청 형태입니다: [%s]".formatted(e.getMessage().split(":")[0]));
+        return ResponseEntity
+                .badRequest()
+                .body(errorMessage);
+    }
+
+    @ExceptionHandler
+    public ResponseEntity<ErrorMessage> handle(Exception e, HttpServletRequest request, HttpServletResponse response) {
+        ErrorMessage errorMessage = new ErrorMessage("서버 관리자에게 문의하세요");
+        StringWriter sw = new StringWriter();
+        PrintWriter pw = new PrintWriter(sw);
+        e.printStackTrace(pw);
+        String stackTrace = sw.toString();
+        request.setAttribute("stackTrace", stackTrace);
+        return ResponseEntity
+                .internalServerError()
+                .body(errorMessage);
+    }
+}

--- a/src/main/java/backend/glloserver/global/repository/entity/BaseTimeEntity.java
+++ b/src/main/java/backend/glloserver/global/repository/entity/BaseTimeEntity.java
@@ -1,0 +1,28 @@
+package backend.glloserver.global.repository.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@Getter
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public abstract class BaseTimeEntity {
+
+    @CreatedDate
+    @NotNull
+    @Column(updatable = false)
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    @NotNull
+    @Column
+    private LocalDateTime updatedAt;
+}

--- a/src/main/java/backend/glloserver/member/controller/MemberController.java
+++ b/src/main/java/backend/glloserver/member/controller/MemberController.java
@@ -1,0 +1,12 @@
+package backend.glloserver.member.controller;
+
+import backend.glloserver.member.service.MemberService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.RestController;
+
+@RequiredArgsConstructor
+@RestController
+public class MemberController {
+
+    private final MemberService memberService;
+}

--- a/src/main/java/backend/glloserver/member/domain/MemberStatus.java
+++ b/src/main/java/backend/glloserver/member/domain/MemberStatus.java
@@ -1,0 +1,5 @@
+package backend.glloserver.member.domain;
+
+public enum MemberStatus {
+    ACTIVE, INACTIVE
+}

--- a/src/main/java/backend/glloserver/member/exception/MemberErrorCode.java
+++ b/src/main/java/backend/glloserver/member/exception/MemberErrorCode.java
@@ -1,0 +1,26 @@
+package backend.glloserver.member.exception;
+
+import backend.glloserver.global.exception.ErrorMessage;
+import backend.glloserver.global.exception.ErrorResponse;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+import static org.springframework.http.HttpStatus.*;
+
+@Getter
+@AllArgsConstructor
+public enum MemberErrorCode implements ErrorResponse {
+    NOT_FOUND(BAD_REQUEST, "해당 사용자가 존재하지 않습니다."),
+    MAX_TRY_EXCEEDED(INTERNAL_SERVER_ERROR, "닉네임 생성에 실패했습니다."),
+    NICK_NAME_READ_FAIL(INTERNAL_SERVER_ERROR, "닉네임 데이터 읽기를 실패했습니다."),
+    NICK_NAME_ALREADY_EXIST(CONFLICT, "이미 사용중인 닉네임입니다.");
+
+    private final HttpStatus status;
+    private final String message;
+
+    @Override
+    public ErrorMessage getErrorMessage() {
+        return new ErrorMessage(this.message);
+    }
+}

--- a/src/main/java/backend/glloserver/member/repository/MemberRepository.java
+++ b/src/main/java/backend/glloserver/member/repository/MemberRepository.java
@@ -1,0 +1,7 @@
+package backend.glloserver.member.repository;
+
+import backend.glloserver.member.repository.entity.MemberEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MemberRepository extends JpaRepository<MemberEntity, Long> {
+}

--- a/src/main/java/backend/glloserver/member/repository/entity/MemberEntity.java
+++ b/src/main/java/backend/glloserver/member/repository/entity/MemberEntity.java
@@ -1,0 +1,19 @@
+package backend.glloserver.member.repository.entity;
+
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.NoArgsConstructor;
+
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "member")
+public class MemberEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+}

--- a/src/main/java/backend/glloserver/member/service/MemberService.java
+++ b/src/main/java/backend/glloserver/member/service/MemberService.java
@@ -1,0 +1,11 @@
+package backend.glloserver.member.service;
+
+import backend.glloserver.member.repository.MemberRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@RequiredArgsConstructor
+@Service
+public class MemberService {
+    private final MemberRepository memberRepository;
+}

--- a/src/main/java/backend/glloserver/member/service/dto/NicknameRequest.java
+++ b/src/main/java/backend/glloserver/member/service/dto/NicknameRequest.java
@@ -1,0 +1,9 @@
+package backend.glloserver.member.service.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+public record NicknameRequest(@NotBlank(message = "닉네임을 입력해주세요.")
+                              @Size(max = 10, message = "닉네임의 최대 길이는 10자 미만입니다.")
+                              String nickname) {
+}


### PR DESCRIPTION
## 📌 관련 이슈
close #3 

## ✨ 작업 내용

헥사고날 아키텍처를 구성하려고 하였으나, 한 도메인 당 9~10개의 클래스 구조가 생겨 불필요한 추상화가 일어날 것이라고 생각했습니다.
또한 저희 서비스는 도메인이 명확하게 구분되어 있으나, 외부 API 연동이 많으므로 과도한 추상화는 필요하지 않다고 판단했습니다.
https://tech.kakaopay.com/post/home-hexagonal-architecture/

**위 테크 블로그에 구성된 헥사고날 아키텍처에 적합한 프로젝트는 다음과 같습니다.**
1. 도메인 모델을 확실하게 정의할 수 있는 서비스
2. 외부 의존성이 많지 않은 서비스

 따라서 DDD 구조를 지향하여 최대한 DDD 구조를 지키기 위하여 패키지 구조를 구성했습니다. 
패키지 구조는 다음과 같습니다.

- controller 패키지 
- domain 패키지 / Value Object(값 객체) ex) enum, 도메인에 필요한 서브 도메인
- exception 패키지 / 각 도메인으로 분리하여 exception을 따로 분리하는 것이 명확하다고 판단했습니다.
- repository 패키지 / entity: 에그리거트(Aggregate) = 실제 도메인, JpaRepository로 구성되어 있습니다.
왜 repository 패키지 내에 entity랑 JpaRepository를 같이 두느냐? -> **DDD 패키지 내에서 영속성 컨텍스트를 관리하는 부분은 한 패키지에 두는 것이 좋다고 판단하였습니다.**
- service 패키지 - dto / 서비스 클래스
<img width="281" alt="image" src="https://github.com/user-attachments/assets/148ef695-6f9c-4ed3-86c7-cb1f639b1792" />

**Global 클래스에 Exception 클래스를 생성하였습니다. 
커스텀 예외와 GlobalExceptionHandler를 통하여 예외 클래스를 처리했습니다.** 
ResponseEntity가 있는 이상, 커스텀 정상 응답은 불필요한 응답이라고 생각하여 예외 처리만 진행하였습니다.

<img width="281" alt="image" src="https://github.com/user-attachments/assets/a466a0a5-4d19-4059-96ff-4e14d797b696" />


## 📚 기타
